### PR TITLE
LinkRelay: added l10n-fi.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/plugins
 *.swp
 *.swo
 *~
+*.mo

--- a/LinkRelay/locale/fi.po
+++ b/LinkRelay/locale/fi.po
@@ -1,0 +1,227 @@
+# LinkRelay plugin for Limnoria.
+# Copyright (C) 2011 Limnoria
+# Mika Suomalainen <mika.henrik.mainio@hotmail.com>, 2011.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2011-02-19 13:26+CET\n"
+"PO-Revision-Date: 2011-08-18 17:25+0200\n"
+"Last-Translator: Mika Suomalainen <mika.henrik.mainio@hotmail.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: config.py:43
+msgid "Value must be a valid color number (01, 02, 03, 04, ..., 16)"
+msgstr "Arvon täytyy olla kelvollinen värikoodin numero (01, 02, 03, 04, ..., 16"
+
+#: config.py:55
+msgid ""
+"Determines whether the bot will color Relayed\n"
+"    PRIVMSGs so as to make the messages easier to read."
+msgstr ""
+"Määrittää värjääkö botti\n"
+"    välitetyt PRIVMSG-viestit tehdäkseen viestit helpommin luettavaksi."
+
+#: config.py:58
+msgid ""
+"Determines whether the bot will synchronize\n"
+"    topics between networks in the channels it Relays."
+msgstr ""
+"Määrittää synkronoiko botti kanavien otsikot kaikkien\n"
+"    verkkojen välillä niillä kanavilla joita se välittää."
+
+#: config.py:61
+msgid ""
+"Determines whether the bot will Relay the\n"
+"    hostmask of the person joining or parting the channel when he or she joins\n"
+"    or parts."
+msgstr ""
+"Määrittää välittääkö botti kanavalle liittyvän tai kanavalta poistuvan henkilön\n"
+"    hostmaskin, kun hän liittyy\n"
+"    tai poistuu."
+
+#: config.py:65
+msgid ""
+"Determines whether the bot will include the\n"
+"    network in Relayed PRIVMSGs; if you're only Relaying between two networks,\n"
+"    it's somewhat redundant, and you may wish to save the space."
+msgstr ""
+"Määrittää sisältääkö botti verkon välitetyissä\n"
+"    PRIVMSGeissä; jos välität vain kahden verkon välillä,\n"
+"    se on aika tarpeetonta, ja saatat tahtoa säästää tilaa."
+
+#: config.py:69
+msgid ""
+"Determines whether the bot will used NOTICEs\n"
+"    rather than PRIVMSGs for non-PRIVMSG Relay messages (i.e., joins, parts,\n"
+"    nicks, quits, modes, etc.)"
+msgstr ""
+"Määrittää käyttääkö botti mielummin NOTICEja, kuin\n"
+"    PRIVMSG:itä ei-PRIVMSG välitysviesteille (esim., liittymiset, poistumiset,\n"
+"    nimimerkit, lopettamiset, tilat, jne.)"
+
+#: config.py:74
+msgid ""
+"You shouldn't edit this configuration variable\n"
+"    yourself unless you know what you do. Use @LinkRelay {add|remove} instead."
+msgstr ""
+"Sinun ei pitäisi muokata tätä asetusarvoa käsin, mikäli\n"
+"    et tiedä mitä teet. Käytä komentoa @LinkRelay {add|remove} sen sijaan."
+
+#: config.py:78
+msgid ""
+"You shouldn't edit this configuration variable\n"
+"    yourself unless you know what you do. Use @LinkRelay (no)substitute instead."
+msgstr "Sinun ei pitäisi muokata tätä asetusarvoa itse, mikäli    et tiedä mitä teet. Käytä komentoa @LinkRelay (no)substitute sen sijaan."
+
+#: config.py:91
+msgid "Color used for relaying %s."
+msgstr "Väri, jota käytetään välittämiseen %s"
+
+#: plugin.py:131
+msgid ""
+"takes no arguments\n"
+"\n"
+"        Returns all the defined relay links"
+msgstr "Palauttaa kaikki määritetyt välityslinkit"
+
+#: plugin.py:158
+msgid "truncated"
+msgstr "katkaistu"
+
+#: plugin.py:181
+msgid "%s changed mode on %s to %s"
+msgstr "%s vaihtoi tilan kanavalla %s %s:ksi."
+
+#: plugin.py:189
+msgid "%s has joined on %s"
+msgstr "%s on liittynyt verkossa %s"
+
+#: plugin.py:195
+msgid "%s has left on %s"
+msgstr "%s on poistunut verkossa %s"
+
+#: plugin.py:201
+msgid "%s has been kicked on %s by %s (%s)"
+msgstr "%s on potkittu verkossa %s, potkinut %s"
+
+#: plugin.py:211
+msgid "%s (%s) changed his nickname to %s"
+msgstr "%s (%s) vaihtoi nimimerkkinsä %s:ksi."
+
+#: plugin.py:220
+msgid "%s has quit on %s (%s)"
+msgstr "%s on lopettanut verkossa %s (%s)"
+
+#: plugin.py:273
+msgid ""
+"[<channel>]\n"
+"\n"
+"        Returns the nicks of the people in the linked channels.\n"
+"        <channel> is only necessary if the message\n"
+"        isn't sent on the channel itself."
+msgstr ""
+"[<kanava>]\n"
+"\n"
+"        Palauttaa linkitetyillä kanavilla olevien nimimerkit.\n"
+"        <Kanava> on vaadittu vain, jos viestiä ei lähetetä kanavalla\n"
+"        itsellään."
+
+#: plugin.py:282
+msgid "I haven't scraped the IRC object for %s yet. Try again in a minute or two."
+msgstr "En ole kaapinut IRC objectia verkolle %s vielä. Yritä uudelleen minuutissa tai kahdessa minuutissa."
+
+#: plugin.py:322
+msgid "%d users in %s on %s:  %s"
+msgstr "%d käyttäjiä verkossa %s kanavalla %s: %s"
+
+#: plugin.py:361
+msgid "You must give at least --from or --to."
+msgstr "Sinun täytyy antaa vähintään --from tai --to."
+
+#: plugin.py:373
+msgid "--from should be like \"--from #channel@network\""
+msgstr "--from pitäisi näyttää tältä: \"--from #kanava@verkko\""
+
+#: plugin.py:376
+msgid "--to should be like \"--to #channel@network\""
+msgstr "--to pitäisi näyttää tältä: \"--to #kanava@verkko\""
+
+#: plugin.py:382
+msgid ""
+"[--from <channel>@<network>] [--to <channel>@<network>] [--regexp <regexp>] [--reciprocal]\n"
+"\n"
+"        Adds a relay to the list. You must give at least --from or --to; if\n"
+"        one of them is not given, it defaults to the current channel@network.\n"
+"        Only messages matching <regexp> will be relayed; if <regexp> is not\n"
+"        given, everything is relayed.\n"
+"        If --reciprocal is given, another relay will be added automatically,\n"
+"        in the opposite direction."
+msgstr ""
+"[--from <kanava>@<verkko>] [--to <kanava>@<verkko>] [--regexp <säännöllinen lauseke>] [--reciprocal]\n"
+"\n"
+"        Lisää välityksen listaan. Sinun täytyy antaa vähintään --from tai --to; jos\n"
+"        yhtä niistä ei ole annettu, se on oletuksenä nykyinen kanava@verkko.\n"
+"        Vain viestit, jotka täsmäävät <säännölliseen lausekkeeseen> välitetään; jos <säännöllinen lauseke> ei ole\n"
+"        annettu, kaikki välitetään.\n"
+"        Jos --reciprocal on annettu, toinen välitys lisätään,\n"
+"        vastapäiseen suuntaan."
+
+#: plugin.py:407
+msgid "One (or more) relay(s) already exists and has not been added."
+msgstr "Yksi (tai useampi) välitys on jo olemassa ja sitä ei lisätty."
+
+#: plugin.py:417
+msgid ""
+"[--from <channel>@<network>] [--to <channel>@<network>] [--regexp <regexp>] [--reciprocal]\n"
+"\n"
+"        Remove a relay from the list. You must give at least --from or --to; if\n"
+"        one of them is not given, it defaults to the current channel@network.\n"
+"        Only messages matching <regexp> will be relayed; if <regexp> is not\n"
+"        given, everything is relayed.\n"
+"        If --reciprocal is given, another relay will be removed automatically,\n"
+"        in the opposite direction."
+msgstr ""
+"[--from <kanava>@<verkko>] [--to <kanava>@<verkko>] [--regexp <säännöllinen lauseke>] [--reciprocal]\n"
+"\n"
+"        Poistaa välityksen listasta. Sinun täytyy antaa vähintään --from tai --to; jos\n"
+"        yksi tai useampi niistä ei ole annettu, se on oletuksena nykyinen kanava@verkko.\n"
+"        Vain viestit, jotka täsmäävät <säännölliseen lausekkeeseen> välitetään; jos <säännöllinen lauseke> ei ole\n"
+"        annettu, kaikki välitetään.\n"
+"        Jos --reciprocal on annettu, toinen välitys poistetaan automaattisesti,\n"
+"        vastapäisessä suunnassa."
+
+#: plugin.py:442
+msgid "One (or more) relay(s) did not exist and has not been removed."
+msgstr "Yksi (tai useampi) välitys ei ollut olemassa, joten sitä ei ole poistettu."
+
+#: plugin.py:475
+msgid ""
+"<regexp> <replacement>\n"
+"\n"
+"        Replaces all nicks that matches the <regexp> by the <replacement>\n"
+"        string."
+msgstr ""
+"<säännöllinen lauseke> <korvaus>\n"
+"\n"
+"        Korvaa kaikki nimimerkit, jotka täsmäävät <säännölliseen lausekkeeseen> <korvaavalla>\n"
+"        merkkiketjulla."
+
+#: plugin.py:492
+msgid ""
+"<regexp>\n"
+"\n"
+"        Undo a substitution."
+msgstr ""
+"<säännöllinen lauseke>\n"
+"\n"
+"        Kumoa korvaaminen."
+
+#: plugin.py:497
+msgid "This regexp was not in the nick substitutions database"
+msgstr "Tämä säännöllinen lauseke ei ollut nimimerkkien korvaus tietokannassa."
+


### PR DESCRIPTION
I skipped some plugins which come by default, because I am relaying one channel with
both Relay and LinkRelay plugin and it looks annoying that the bot says everything with
two different languages.

I added *.mo to .gitignore, because your implementation doesn't require them
and Poedit creates them automaticly.
