### PR TITLE
GitHub doesn't support å in name.

### DIFF
--- a/GitHub/plugin.py
+++ b/GitHub/plugin.py
@@ -130,7 +130,7 @@ class GitHub(callbacks.Plugin):
                      url)
             if hidden is not None:
                 s += _(' (+ %i hidden commits)') % hidden
-            return ircmsgs.privmsg(channel, s)
+            return ircmsgs.privmsg(channel, s.encode('utf8'))
 
         def onPayload(self, payload):
             repo = '%s/%s' % (payload['repository']['owner']['name'],


### PR DESCRIPTION
Or in the commit message I suspect.

This allows 'å' in the name atleast.
