### PR TITLE
IMDb: fix match for \u2013

### DIFF
--- a/IMDb/plugin.py
+++ b/IMDb/plugin.py
@@ -136,7 +136,7 @@ class IMDb(callbacks.Plugin):
         if elem:
             year = elem[0].text
         else:
-            year = unid(root.xpath('//h1[span/@itemprop="name"]/span[last()]')[0].text.strip().strip(')(').replace(u('\u2013', '-')))
+            year = unid(root.xpath('//h1[span/@itemprop="name"]/span[last()]')[0].text.strip().strip(')(').replace(u'\u2013','-'))
 
         elem = root.xpath('//div[@class="star-box-details"]/strong/span|//div[@class="star-box-details"]/span[@class="mellow"]/span')
         if elem:


### PR DESCRIPTION
This fixes the following exception:

```
ERROR 2013-08-14T00:38:49 supybot Uncaught exception in ['imdb'].
Traceback (most recent call last):
  File "/home/kytv/test-limnoria/lib/python2.7/site-packages/supybot/callbacks.py", line 1271, in _callCommand
    self.callCommand(command, irc, msg, *args, **kwargs)
  File "/home/kytv/test-limnoria/lib/python2.7/site-packages/supybot/utils/python.py", line 86, in g
    f(self, *args, **kwargs)
  File "/home/kytv/test-limnoria/lib/python2.7/site-packages/supybot/callbacks.py", line 1252, in callCommand
    method(irc, msg, *args, **kwargs)
  File "/home/kytv/test-limnoria/lib/python2.7/site-packages/supybot/commands.py", line 1077, in newf
    f(self, irc, msg, args, *state.args, **state.kwargs)
  File "/home/kytv/test-limnoria/plugins/IMDb/plugin.py", line 144, in imdb
    year = unid(root.xpath('//h1[span/@itemprop="name"]/span[last()]')[0].text.strip().strip(')(').replace(u('\u2013', '-')))
TypeError: u() takes exactly 1 argument (2 given)
ERROR 2013-08-14T00:38:49 supybot Exception id: 0x574fa
```
