### PR TITLE
.travis.yml: do not spam with emails about failed builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ script:
   - echo $TRAVIS_PYTHON_VERSION
   - supybot-test --plugins-dir=. --no-network --exclude=WebStats --exclude=Seeks --exclude=Rbls --exclude=MilleBornes --exclude=Scheme --exclude=Twitter --exclude=TwitterStream --exclude=MegaHAL --exclude=Webstats --exclude=NoLatin1 --exclude=GUI --exclude=SupySandbox
 notifications:
-    on_success: change
-    on_failure: change
+    on_success: never
+    on_failure: never


### PR DESCRIPTION
We know that this repository always fails.

This makes Travis send emails if the build breaks down or starts working.
