### PR TITLE
ChannelStats: enable Topic by default.

### DIFF
--- a/ChannelStatus/config.py
+++ b/ChannelStatus/config.py
@@ -58,7 +58,7 @@ conf.registerChannelValue(ChannelStatus, 'nicks',
     registry.Boolean(False, _("""Determines whether or not the list of users
     in this channel will be listed.""")))
 conf.registerChannelValue(ChannelStatus, 'topic',
-    registry.Boolean(False, _("""Determines whether or not the topic of this
+    registry.Boolean(True, _("""Determines whether or not the topic of this
     channel will be displayed.""")))
 
 


### PR DESCRIPTION
If the channel is not mode `+s`, random stats getting bots notice it, join there and publish the topic anyway. Examples:
- http://irc.netsplit.de/channels/details.php?room=%23limnoria&net=freenode
- http://irc.netsplit.de/channels/details.php?room=%23supybot&net=freenode
