### PR TITLE
LimnoriaChan: update links to the git repositories

### DIFF
--- a/LimnoriaChan/plugin.py
+++ b/LimnoriaChan/plugin.py
@@ -45,8 +45,8 @@ _ = PluginInternationalization('LimnoriaChan')
 WEB_REPO = 'https://github.com/ProgVal/Limnoria'
 PLUGINS_WEB_REPO = 'https://github.com/ProgVal/Supybot-plugins'
 staticFactoids = {
-        'git':          'git://github.com/ProgVal/Limnoria.git',
-        'git-pl':       'git://github.com/ProgVal/Supybot-plugins.git',
+        'git':          WEB_REPO + '.git',
+        'git-pl':       PLUGINS_WEB_REPO + '.git',
         'gh':           WEB_REPO,
         'gh-pl':        PLUGINS_WEB_REPO,
         'wiki':         WEB_REPO + '/wiki',


### PR DESCRIPTION
If you go to any git repository page on GitHub, you have the options to clone with `https`, `ssh` or `subversion`. I don't know if they are planning to retire `git://` or something.
