### PR TITLE
WebStats: add more information to generated time.

### DIFF
--- a/WebStats/plugin.py
+++ b/WebStats/plugin.py
@@ -206,7 +206,7 @@ PAGE_SKELETON = """\
         </p>
     </body>
 </html>
-""" % time.strftime('%H:%M:%S')
+""" % time.strftime('%Y-%m-%d %H:%M:%S %Z')
 
 DEFAULT_TEMPLATES = {
         'webstats/design.css': """\


### PR DESCRIPTION
The format is now `%Y-%m-%d %H:%M:%S %Z` which translates to something
like `2014-05-30 12:45:48 EEST`.
