### PR TITLE
WebLogs: use ISO 8601 date format.

### DIFF
--- a/WebLogs/plugin.py
+++ b/WebLogs/plugin.py
@@ -176,14 +176,14 @@ def format_logs(logs):
 
             # Timestamp handling
             gmtime = time.gmtime(int(words[0]))
-            gmtime_day = (gmtime.tm_mday, gmtime.tm_mon, gmtime.tm_year)
+            gmtime_day = (gmtime.tm_year, gmtime.tm_mon, gmtime.tm_mday)
             if old_gmtime_day != gmtime_day:
                 html_logs += '</div><div class="day">'
                 html_logs += """
                     <input type="button" value="reveal" class="reveal" />
                     <input type="button" value="hide" class="hide" />
                     """
-                html_logs += '<h1>%i/%i/%i</h1>' % \
+                html_logs += '<h1>%i-%i-%i</h1>' % \
                         gmtime_day
                 old_gmtime_day = gmtime_day
             timestamp = time.strftime('%H:%M:%S', gmtime)


### PR DESCRIPTION
Squashed commit of the following:

commit 86ccca9ac6a8b42005003884f61ec1c0d799436b
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Fri May 30 15:36:32 2014 +0300

```
WebLogs: Use `-` as separator instead of `/`. See ISO 8601.
```

commit d8b37954a36bc468c82832acaf7f13dc3f1b8c79
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Fri May 30 15:34:48 2014 +0300

```
fix f10bbbed3e6fd6b110381e7430e94034646257eb
```

commit f10bbbed3e6fd6b110381e7430e94034646257eb
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Fri May 30 15:29:39 2014 +0300

```
WebLogs: use ISO 8601 for showing date.
```
