### PR TITLE
WebStats: fix ISO 8601 time.

### DIFF
--- a/WebStats/plugin.py
+++ b/WebStats/plugin.py
@@ -206,7 +206,7 @@ PAGE_SKELETON = """\
         </p>
     </body>
 </html>
-""" % time.strftime('%Y-%m-%d %H:%M:%S %Z')
+""" % time.strftime('%Y-%m-%d %H:%M:%S%z')
 
 DEFAULT_TEMPLATES = {
         'webstats/design.css': """\


### PR DESCRIPTION
It seems that I confused `%Z` with `%z` and the latter makes more sense as it shows the offset to UTC. See also ProgVal/Limnoria#701 .
