### PR TITLE
LinkRelay: sync config with Relay

### DIFF
--- a/LinkRelay/config.py
+++ b/LinkRelay/config.py
@@ -82,7 +82,7 @@ conf.registerChannelValue(LinkRelay, 'includeNetwork',
 class ValidNonPrivmsgsHandling(registry.OnlySomeStrings):
     validStrings = ('privmsg', 'notice', 'nothing')
 conf.registerChannelValue(LinkRelay, 'nonPrivmsgs',
-    ValidNonPrivmsgsHandling('notice', _("""Determines whether the
+    ValidNonPrivmsgsHandling('privmsg', _("""Determines whether the
     bot will use PRIVMSGs (privmsg), NOTICEs (notice), for non-PRIVMSG Relay
     messages (i.e., joins, parts, nicks, quits, modes, etc.), or whether it
     won't relay such messages (nothing)""")))


### PR DESCRIPTION
Please see https://github.com/TkTech/notifico/issues/79
- > There is a difference between a NOTICE to a channel and a NOTICE to a user, every client should be able to correctly display notices to a channel. ~~ @Dav1dde
- > They should, but they don't. ~~ @Mkaysi
- > That's besides the point. There are a lot of clients that do handle it properly, and if they don't then that's not notifico's fault, that's their own fault. ~~ @sckasturi
