### PR TITLE
.travis.yml: use the Limnoria's testing branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-    - pip install -v limnoria
+    - pip install -v git+https://github.com/ProgVal/Limnoria.git@testing
     - pip install -vr requirements.txt
 # command to run tests, e.g. python setup.py test
 script:


### PR DESCRIPTION
- This might help if something changes in testing and causes breakage here too.
- testing branch is updated more often than pip which was forgotten often in the past and is based on master branch anyway.
