### PR TITLE
.travis.yml: install Limnoria's requirements too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-    - pip install -v git+https://github.com/ProgVal/Limnoria.git@testing
     - pip install -vr https://raw.githubusercontent.com/ProgVal/Limnoria/testing/requirements.txt
+    - pip install -v git+https://github.com/ProgVal/Limnoria.git@testing
     - pip install -vr requirements.txt
 # command to run tests, e.g. python setup.py test
 script:


### PR DESCRIPTION
pip install appears to ignore `requirements.txt` file.

I primarily made this commit to test am I right with the previous claim and as I am and already did this, I thought that you might want to merge this too.

I am opening pull requests to Limnoria soon.
