### PR TITLE
.travis.yml: enable fast finishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ script:
 notifications:
     on_success: never
     on_failure: never
+matrix:
+    fast_finish: true


### PR DESCRIPTION
As with Limnoria, this sets the build as failed/errorred immediately
when one build fails without having to wait for so long time.

As we noticed with Limnoria, the builds that haven't failed at the time
of one build failing will continue building and this only gives
information about build failing faster.
