### PR TITLE
Try to fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - echo $TRAVIS_PYTHON_VERSION
-  - export PYTHON_MAJOR_VERSION=$(python -c "import sys;print(sys.version_info.major)")
+  - export PYTHON_MAJOR_VERSION=$(python -c "import sys;print(sys.version_info[0])")
   - echo $PYTHON_MAJOR_VERSION
   - if [ "$PYTHON_MAJOR_VERSION" = "3" ]; then export DISABLED_PLUGINS="--exclude=./NoLatin1"; else export DISABLED_PLUGINS=""; fi
   - supybot-test --plugins-dir=. --no-network $DISABLED_PLUGINS


### PR DESCRIPTION
- Allow installing of requirements.txt to not fail the build by piping it to `true`.
- Add pypy3 which is also tested with Limnoria.
- Comment alllow_failures as the only failure was in requirements.txt.

If you are wondering why I used `pip install -vr requirements.txt||true` instead of `pip install -vr requirements.txt || true`, it's because Travis transformed spaces to some weird characters and failed the build with command not found for strange characters.
