### PR TITLE
LinkRelay: use Supybot's built-in ignore (Closes #143)

### DIFF
--- a/LinkRelay/plugin.py
+++ b/LinkRelay/plugin.py
@@ -55,7 +55,6 @@ except:
 @internationalizeDocstring
 class LinkRelay(callbacks.Plugin):
     """Advanced message relay between channels."""
-    noIgnore = True
     threaded = True
 
     class Relay():


### PR DESCRIPTION
_Rationale:_ having working ignore in the relay plugin can be helpful when ignoring services' mode changes in semi-high traffic channels. 

After some thought, I don't think a separate ignore mechanism would be needed for just one plugin, as ignoring services bots shouldn't make much of a difference because they don't communicate with the bot anyways.
