### PR TITLE
fixes for non-english wikipedia (closes #226)

### DIFF
--- a/Wikipedia/locales/fr.po
+++ b/Wikipedia/locales/fr.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Supybot-fr\n"
 "POT-Creation-Date: 2011-03-02 11:00+CET\n"
 "PO-Revision-Date: 2011-03-02 11:06+0100\n"
-"Last-Translator: Valentin Lorentz <progval@gmail.com>\n"
+"Last-Translator: James Lu <glolol1@hotmail.com>\n"
 "Language-Team: ProgVal <progval@gmail.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,10 +55,6 @@ msgstr "Je ne peux rien trouver pour \"%s\", mais voici le résultat de \"%s\" :
 msgid "Redirected from"
 msgstr "Redirigé de"
 
-#: plugin.py:109
-msgid "Retrieved from"
-msgstr "Recu de"
-
 #: plugin.py:118
 msgid "%s is a disambiguation page. Possible results are: %s"
 msgstr "%s est une page de désambiguation. Les résultats possibles son : %s"
@@ -75,3 +71,6 @@ msgstr "\"%s\" est une page pleine d'évènement qui se sont produits cette ann�
 msgid "Not found, or page bad formed."
 msgstr "Non trouvé, ou page mal formée."
 
+#: plugin.py:168
+msgid "Retrieved from"
+msgstr "Recu de"

--- a/Wikipedia/locales/it.po
+++ b/Wikipedia/locales/it.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Supybot-fr\n"
 "POT-Creation-Date: 2011-02-26 09:49+CET\n"
 "PO-Revision-Date: 2011-07-29 17:43+0200\n"
-"Last-Translator: skizzhg <skizzhg@gmx.com>\n"
+"Last-Translator: James Lu <glolol1@hotmail.com>\n"
 "Language-Team: Italian <skizzhg@gmx.com>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
@@ -53,10 +53,6 @@ msgstr "Non trovo nulla per \"%s\", ma questi sono i risultati per \"%s\": "
 msgid "Redirected from"
 msgstr "Rediretto da"
 
-#: plugin.py:109
-msgid "Retrieved from"
-msgstr "Recuperato da"
-
 #: plugin.py:118
 msgid "%s is a disambiguation page. Possible results are: %s"
 msgstr "%s è una pagina di disambiguazione; i possibili risultati sono: %s"
@@ -73,3 +69,6 @@ msgstr "\"%s\" è una pagina piena di eventi accaduti quest'anno. Se stavi cerca
 msgid "Not found, or page bad formed."
 msgstr "Non trovato, o pagina non valida."
 
+#: plugin.py:168
+msgid "Retrieved from"
+msgstr "Recuperato da"

--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -133,7 +133,7 @@ class Wikipedia(callbacks.Plugin):
                         redirect = redirect.encode('utf-8','replace')
                 reply += '"%s" (Redirect from "%s"): ' % (title, redirect)
         # extract the address we got it from
-        addr = re.search(_('Retrieved from') + ' "<a dir="ltr" href="([^"]*)">', article)
+        addr = re.search(' "?<a dir="ltr" href="([^"]*)"?>', article)
         addr = addr.group(1)
         # check if it's a disambiguation page
         disambig = tree.xpath('//table[@id="disambigbox"]')
@@ -165,7 +165,7 @@ class Wikipedia(callbacks.Plugin):
                         p = p.encode('utf-8', 'replace')
                     if isinstance(reply, unicode):
                         reply = reply.encode('utf-8','replace')
-                reply += '%s %s' % (p, ircutils.bold(addr))
+                reply += '%s %s %s' % (p, _('Retrieved from'), ircutils.bold(addr))
         reply = reply.replace('&amp;','&')
         irc.reply(reply)
     wiki = wrap(wiki, ['text'])


### PR DESCRIPTION
I have found that Wikipedia is not completely consistent when it comes to formatting in different languages, hence breaking the regex used to parse the articles (ref #226, #191)
