### PR TITLE
LinkRelay: remove unused topicSync config variable

### DIFF
--- a/LinkRelay/config.py
+++ b/LinkRelay/config.py
@@ -64,9 +64,6 @@ LinkRelay = conf.registerPlugin('LinkRelay')
 conf.registerChannelValue(LinkRelay, 'color',
     registry.Boolean(True, _("""Determines whether the bot will color Relayed
     PRIVMSGs so as to make the messages easier to read.""")))
-conf.registerChannelValue(LinkRelay, 'topicSync',
-    registry.Boolean(True, _("""Determines whether the bot will synchronize
-    topics between networks in the channels it Relays.""")))
 conf.registerChannelValue(LinkRelay, 'hostmasks',
     registry.Boolean(True, _("""Determines whether the bot will Relay the
     hostmask of the person joining or parting the channel when he or she joins


### PR DESCRIPTION
This seems like a leftover variable from the Relay plugin, looking at [its source](https://github.com/ProgVal/Limnoria/blob/master/plugins/Relay/config.py#L61-L63). 

This variable is completely unused in this plugin's plugin.py, so keeping it around without actually implementing anything will just lead to confusion.
