### PR TITLE
Wikipedia: show HTTPS links without &oldid (Closes #232)

### DIFF
--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -135,6 +135,10 @@ class Wikipedia(callbacks.Plugin):
         # extract the address we got it from
         addr = re.search(' "?<a dir="ltr" href="([^"]*)"?>', article)
         addr = addr.group(1)
+        # remove the &oldid part
+        addr = addr.split('&amp;oldid=')[0]
+        # force serving HTTPS links
+        addr = 'https://' + addr.split("//")[1]
         # check if it's a disambiguation page
         disambig = tree.xpath('//table[@id="disambigbox"]')
         if disambig:


### PR DESCRIPTION
I'm not sure if this is the best long term solution for #232, but Wikipedia currently hard-codes the `http://` and `&oldid` parts into its `Retrieved from` link. I don't see any other way of fixing this issue without editing the link ourselves.

Bearing in mind though that websites' layouts do change at times, and even the slightest changes can completely break the plugin (#186, #226 as examples).

edit: This also really fixes #59.
