### PR TITLE
Wikipedia: fix a small grammatical error

### DIFF
--- a/Wikipedia/locales/fr.po
+++ b/Wikipedia/locales/fr.po
@@ -68,7 +68,7 @@ msgid "\"%s\" is a page full of events that happened in that year.  If you were 
 msgstr "\"%s\" est une page pleine d'évènement qui se sont produits cette année. Si vous recherches des informations à propos du nombre lui-même, essayez de rechercher \"%s_(nombre)\", mais ne vous attendez pas à quelque chose d'utile..."
 
 #: plugin.py:131
-msgid "Not found, or page bad formed."
+msgid "Not found, or page malformed."
 msgstr "Non trouvé, ou page mal formée."
 
 #: plugin.py:168

--- a/Wikipedia/locales/it.po
+++ b/Wikipedia/locales/it.po
@@ -66,7 +66,7 @@ msgid "\"%s\" is a page full of events that happened in that year.  If you were 
 msgstr "\"%s\" è una pagina piena di eventi accaduti quest'anno. Se stavi cercando informazioni sul numero prova \"%s_(numero)\", ma non aspettarti niente di utile..."
 
 #: plugin.py:131
-msgid "Not found, or page bad formed."
+msgid "Not found, or page malformed."
 msgstr "Non trovato, o pagina non valida."
 
 #: plugin.py:168

--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -155,7 +155,7 @@ class Wikipedia(callbacks.Plugin):
             ##### etree!
             p = tree.xpath("//div[@id='mw-content-text']/p[1]")
             if len(p) == 0 or addr.endswith('Special:Search'):
-                reply += _('Not found, or page bad formed.')
+                reply += _('Not found, or page malformed.')
             else:
                 p = p[0]
                 p = p.text_content()


### PR DESCRIPTION
It should be either "page malformed" or "page badly formed".
