### PR TITLE
Github: Fix exception

### DIFF
--- a/GitHub/plugin.py
+++ b/GitHub/plugin.py
@@ -220,7 +220,7 @@ class GitHub(callbacks.Plugin):
                     else:
                         repl[key + '__tiny'] = value
                         try_gitio = False
-                elif key.endswith('ref'):
+                elif key.endswith('ref') and value:
                     try:
                         repl[key + '__branch'] = value.split('/', 2)[2]
                     except IndexError:


### PR DESCRIPTION
'base_ref' is always _None_ for me, I'm not sure if that is ever needed.
