### PR TITLE
Wikipedia: s/Possible results are/Possible results include/

### DIFF
--- a/Wikipedia/locales/fr.po
+++ b/Wikipedia/locales/fr.po
@@ -56,7 +56,7 @@ msgid "Redirected from"
 msgstr "Redirigé de"
 
 #: plugin.py:118
-msgid "%s is a disambiguation page. Possible results include: %s"
+msgid "%s is a disambiguation page. Possible results are: %s"
 msgstr "%s est une page de désambiguation. Les résultats possibles son : %s"
 
 #: plugin.py:121

--- a/Wikipedia/locales/it.po
+++ b/Wikipedia/locales/it.po
@@ -54,7 +54,7 @@ msgid "Redirected from"
 msgstr "Rediretto da"
 
 #: plugin.py:118
-msgid "%s is a disambiguation page. Possible results include: %s"
+msgid "%s is a disambiguation page. Possible results are: %s"
 msgstr "%s è una pagina di disambiguazione; i possibili risultati sono: %s"
 
 #: plugin.py:121


### PR DESCRIPTION
The usage of `Possible results are:` is a bit misleading IMO since it suggests that all disambiguation results are shown, when in fact, only the first five are.
