### PR TITLE
Wikipedia: handle set indice boxes like disambiguation pages

### DIFF
--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -135,7 +135,8 @@ class Wikipedia(callbacks.Plugin):
         # force serving HTTPS links
         addr = 'https://' + addr.split("//")[1]
         # check if it's a disambiguation page
-        disambig = tree.xpath('//table[@id="disambigbox"]')
+        disambig = tree.xpath('//table[@id="disambigbox"]') or \
+            tree.xpath('//table[@id="setindexbox"]')
         if disambig:
             disambig = tree.xpath('//div[@id="bodyContent"]/div/ul/li/a')
             disambig = disambig[:5]


### PR DESCRIPTION
Example article: !wiki [Windows 3](https://en.wikipedia.org/wiki/Windows_3.x)

Old, wrong output:

```
<GLolol> `wiki windows 3
<Atlas> Windows 3.x can refer to any of the following versions of Microsoft Windows: Retrieved from <https://en.wikipedia.org/w/index.php?title=Windows_3.x>
```

Correct output:

```
<GLolol> `wiki windows 3
<Atlas> <https://en.wikipedia.org/w/index.php?title=Windows_3.x> is a disambiguation page. Possible results include: Windows 3.0, Windows 3.1x, and Windows NT 3.x
```
