### PR TITLE
Wikipedia: add showRedirects option for toggling redirect output

### DIFF
--- a/Wikipedia/config.py
+++ b/Wikipedia/config.py
@@ -59,5 +59,8 @@ conf.registerChannelValue(Wikipedia, 'url',
         registry.String(_('en.wikipedia.org'), _("""URL of the website from
         where you want to pull pages (usually: your language's
         wikipedia)""")))
+conf.registerChannelValue(Wikipedia, 'showRedirects',
+        registry.Boolean(True, _("""Determines whether redirect paths will
+        be shown in the output.)""")))
 
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:

--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -87,8 +87,9 @@ class Wikipedia(callbacks.Plugin):
                     redirect = redirect.encode('utf-8','replace')
                 if isinstance(search, unicode):
                     search = search.encode('utf-8','replace')
-            reply += _('I didn\'t find anything for "%s". '
-                       'Did you mean "%s"? ') % (search, redirect)
+            if self.registryValue('showRedirects', msg.args[0]):
+                reply += _('I didn\'t find anything for "%s". '
+                           'Did you mean "%s"? ') % (search, redirect)
             addr = self.registryValue('url', msg.args[0]) + \
                    didyoumean[0].get('href')
             if not article.startswith('http'):
@@ -102,8 +103,9 @@ class Wikipedia(callbacks.Plugin):
         searchresults = tree.xpath('//div[@class="searchresults"]/ul/li/a')
         if searchresults:
             redirect = searchresults[0].text_content().strip()
-            reply += _('I didn\'t find anything for "%s", but here\'s the '
-                     'result for "%s": ') % (search, redirect)
+            if self.registryValue('showRedirects', msg.args[0]):
+                reply += _('I didn\'t find anything for "%s", but here\'s the '
+                           'result for "%s": ') % (search, redirect)
             addr = self.registryValue('url', msg.args[0]) + \
                    searchresults[0].get('href')
             article = utils.web.getUrl(addr)
@@ -113,7 +115,7 @@ class Wikipedia(callbacks.Plugin):
             tree = lxml.html.document_fromstring(article)
             search = redirect
         # otherwise, simply return the title and whether it redirected
-        else:
+        elif self.registryValue('showRedirects', msg.args[0]):
             redirect = re.search('\(%s <a href=[^>]*>([^<]*)</a>\)' %
                                  _('Redirected from'), article)
             if redirect:


### PR DESCRIPTION
Sometimes showing redirects adds a lot of clutter to an already cramped snippet space, making text a lot harder to read. This adds a configuration option to turn redirect showing on or off.

Before:

```
<+GLolol> `wiki Widnows
<@Atlas> I didn't find anything for "Widnows". Did you mean "windows"? "Microsoft Windows" (Redirected from "Windows"): Microsoft Windows or Windows is a metafamily of graphical operating systems developed, marketed, and sold by Microsoft. It consists of several families of operating systems, each of which cater to a certain sector of the computing industry. Active Windows families include Windows NT, (1 more message)
```

After (with showRedirects off):

```
<+GLolol> `wiki Widnows
<@Atlas> Microsoft Windows or Windows is a metafamily of graphical operating systems developed, marketed, and sold by Microsoft. It consists of several families of operating systems, each of which cater to a certain sector of the computing industry. Active Windows families include Windows NT, Windows Embedded and Windows Phone; these may encompass subfamilies, e.g. Windows Embedded Compact (Windows CE) or (1 more message)
```
