### PR TITLE
Wikipedia: replace <b> and </b> with \x02 for bold output

### DIFF
--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -158,7 +158,12 @@ class Wikipedia(callbacks.Plugin):
                 reply += _('Not found, or page malformed.')
             else:
                 p = p[0]
+                # Replace <b> tags with IRC-style bold, this has to be
+                # done indirectly because unescaped '\x02' is invalid in XML
+                for b_tag in p.xpath('//b'):
+                    b_tag.text = "&#x02;%s&#x02;" % b_tag.text
                 p = p.text_content()
+                p = p.replace('&#x02;', '\x02')
                 p = p.strip()
                 if sys.version_info[0] < 3:
                     if isinstance(p, unicode):


### PR DESCRIPTION
This is a bit of an ugly hack, but the bolding works well in certain Wikipedia articles and makes the text snippet easier to read.

Using etree's built in replace will cause an error since `\x02` isn't an allowed character in XML. Therefore, I have to do this indirectly using replaces (I don't know of a better way!)
