### PR TITLE
Wikipedia: fix for yet another change in Wikipedia's layout

### DIFF
--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -130,12 +130,13 @@ class Wikipedia(callbacks.Plugin):
                         redirect = redirect.encode('utf-8','replace')
                 reply += '"%s" (Redirected from "%s"): ' % (title, redirect)
         # extract the address we got it from
-        addr = re.search(' "?<a dir="ltr" href="([^"]*)"?>', article)
-        addr = addr.group(1)
-        # remove the &oldid part
-        addr = addr.split('&amp;oldid=')[0]
-        # force serving HTTPS links
-        addr = 'https://' + addr.split("//")[1]
+        addr = tree.find(".//link[@rel='canonical']")
+        addr = addr.attrib['href']
+        try:
+            # force serving HTTPS links
+            addr = 'https://' + addr.split("//")[1]
+        except:
+            pass
         # check if it's a disambiguation page
         disambig = tree.xpath('//table[@id="disambigbox"]') or \
             tree.xpath('//table[@id="setindexbox"]')


### PR DESCRIPTION
The address fetching was broken, so I replaced it with some code that looks for a line:

`<link rel="canonical" href="http://en.wikipedia.org/wiki/Wikipedia" />`

at the start of the page. This seems to be consistent across Wikipedia languages, and also removes the hassle of having to strip the `&oldid=` part from the output link.