### PR TITLE
GitHub: Add an optional summary line for the push event

### DIFF
--- a/GitHub/config.py
+++ b/GitHub/config.py
@@ -64,6 +64,12 @@ conf.registerGlobalValue(GitHub, 'announces',
         add' or '@Github announce remove' instead.""")))
 
 conf.registerGroup(GitHub, 'format')
+conf.registerGroup(GitHub.format, 'before')
+conf.registerChannelValue(GitHub.format.before, 'push',
+        registry.String('',
+        _("""Format for an optional summary line before the individual commits
+        in the push event.""")))
+
 conf.registerChannelValue(GitHub.format, 'push',
         registry.String('echo ' +
         _('$repository__owner__name/\x02$repository__name\x02 '

--- a/GitHub/plugin.py
+++ b/GitHub/plugin.py
@@ -225,6 +225,8 @@ class GitHub(callbacks.Plugin):
                     repl[key + '__tiny'] = value
                 elif key.endswith(('commit__id', 'commit_id')):
                     repl[key + '__short'] = value[0:7]
+                elif key == 'commits':
+                    repl['__num_commits'] = len(value)
                 elif key.endswith('ref'):
                     try:
                         repl[key + '__branch'] = value.split('/', 2)[2] \
@@ -306,6 +308,8 @@ class GitHub(callbacks.Plugin):
                             hidden = len(commits) + 1
                             commits = [last_commit]
                         payload2 = dict(payload)
+                        self._createPrivmsg(irc, channel, payload2,
+                            'before.push', None)
                         for commit in commits:
                             payload2['__commit'] = commit
                             self._createPrivmsg(irc, channel, payload2,


### PR DESCRIPTION
This makes it possible to display a summary before the individual
commits in the event are printed.

Here is a working example:

```
<@Caroline> [sandbox] nyuszika7h pushed 3 commits to moo http://git.io/vThiY
<@Caroline> [sandbox] nyuszika7h 915a600 Add foo
<@Caroline> [sandbox] nyuszika7h 0b23065 Add bar
<@Caroline> [sandbox] nyuszika7h 2943c5e Add baz
```