### PR TITLE
Python 2 compatibility

### DIFF
--- a/Glob2Chan/pygeoip.py
+++ b/Glob2Chan/pygeoip.py
@@ -11,7 +11,7 @@ import os
 import sys
 import struct
 
-if sys.version_info[0] >= 3:
+if sys.version_info[0] < 3:
     from io import BytesIO
 else:
     from cBytesIO import BytesIO as BytesIO


### PR DESCRIPTION
if major version is less than 3, then import from io, not if its greater than or equal to 3