### PR TITLE
GitHub: New implementation of hidden commits

### DIFF
--- a/GitHub/config.py
+++ b/GitHub/config.py
@@ -65,6 +65,11 @@ conf.registerGlobalValue(GitHub, 'announces',
 conf.registerGlobalValue(GitHub.announces, 'secret',
         registry.SpaceSeparatedSetOfStrings(set(), _("""Set of space-separated
         secret payloads used to authenticate GitHub."""), private=True))
+conf.registerChannelValue(GitHub, 'max_announce_commits',
+        registry.Integer(3, _("""Determines the maximum number of commits that
+        will be announced for a single push. Note that if the number of commits
+        is only one over the limit, it will be announced anyway instead of
+        saying "1 more commit".""")))
 
 conf.registerGroup(GitHub, 'format')
 conf.registerGroup(GitHub.format, 'before')
@@ -80,6 +85,9 @@ conf.registerChannelValue(GitHub.format, 'push',
         '\x02$__commit__message__firstline\x02 $__commit__url__tiny') \
         .replace('\n        ', ' '),
         _("""Format for push events.""")))
+conf.registerChannelValue(GitHub.format, 'push_hidden',
+        registry.String('echo (+$__hidden_commits hidden commits)',
+        _("""Format for the hidden commits message for push events.""")))
 conf.registerChannelValue(GitHub.format, 'commit_comment',
         registry.String('echo ' +
         _('$repository__owner__login/\x02$repository__name\x02: '

--- a/GitHub/config.py
+++ b/GitHub/config.py
@@ -85,7 +85,7 @@ conf.registerChannelValue(GitHub.format, 'push',
         '\x02$__commit__message__firstline\x02 $__commit__url__tiny') \
         .replace('\n        ', ' '),
         _("""Format for push events.""")))
-conf.registerChannelValue(GitHub.format, 'push_hidden',
+conf.registerChannelValue(GitHub.format.push, 'hidden',
         registry.String('echo (+$__hidden_commits hidden commits)',
         _("""Format for the hidden commits message for push events.""")))
 conf.registerChannelValue(GitHub.format, 'commit_comment',

--- a/GitHub/plugin.py
+++ b/GitHub/plugin.py
@@ -321,7 +321,8 @@ class GitHub(callbacks.Plugin):
                         hidden = None
                         last_commit = commits[-1]
 
-                        max_comm = self.registryValue('max_announce_commits')
+                        max_comm = self.plugin.registryValue(
+                                'max_announce_commits', channel)
 
                         if len(commits) > max_comm + 1:
                             # Limit to the specified number of commits,
@@ -340,7 +341,7 @@ class GitHub(callbacks.Plugin):
                     if hidden:
                         payload2['__hidden_commits'] = hidden
                         self._createPrivmsg(irc, channel, payload2,
-                                'push_hidden')
+                                'push.hidden')
                 elif event == 'gollum':
                     pages = payload['pages']
                     if len(pages) == 0:


### PR DESCRIPTION
This shows the number of hidden commits on a separate line, because something was broken with the old implementation and this is easier to implement.

The maximum number of commits shown for a push is configurable, and defaults to 3. When the number of commits is only one over the limit, the last commit will be shown anyway, because it would be a waste of a line to say "1 more commit" when the actual commit can be shown on that line.