### PR TITLE
IgnoreNonVoice: Fix invalid command handling

### DIFF
--- a/IgnoreNonVoice/README.md
+++ b/IgnoreNonVoice/README.md
@@ -1,4 +1,4 @@
-This plugin ignores users who aren't voiced. Can also be configured to 
-only work when the channel is moderated `mode +m`. Useful with reduced 
-moderation (`mode +z`) on charybdis-based IRCds (including freenode's 
+This plugin ignores users who aren't voiced. Can also be configured to
+only work when the channel is moderated `mode +m`. Useful with reduced
+moderation (`mode +z`) on charybdis-based IRCds (including freenode's
 ircd-seven).

--- a/IgnoreNonVoice/__init__.py
+++ b/IgnoreNonVoice/__init__.py
@@ -29,8 +29,10 @@
 ###
 
 """
-Add a description of the plugin (to be presented to the user inside the wizard)
-here.  This should describe *what* the plugin does.
+This plugin ignores users who aren't voiced. Can also be configured to
+only work when the channel is moderated `mode +m`. Useful with reduced
+moderation (`mode +z`) on charybdis-based IRCds (including freenode's
+ircd-seven).
 """
 
 import supybot

--- a/IgnoreNonVoice/plugin.py
+++ b/IgnoreNonVoice/plugin.py
@@ -53,7 +53,7 @@ class IgnoreNonVoice(callbacks.Plugin):
         callbacks.Commands.pre_command_callbacks.remove(
                 self._pre_command_callback)
 
-    def _is_not_ignored(self, irc, msg):
+    def _is_ignored(self, irc, msg):
         channel = msg.args[0]
         if not ircutils.isChannel(channel) or \
                 channel not in irc.state.channels:
@@ -63,11 +63,13 @@ class IgnoreNonVoice(callbacks.Plugin):
                 'm' in irc.state.channels[channel].modes)
         return enabled and \
                 not irc.state.channels[channel].isVoicePlus(msg.nick)
+
     def _pre_command_callback(self, plugin, command, irc, msg, *args, **kwargs):
-        return self._is_not_ignored(irc, msg)
+        # Prevent the command from executing if the user is ignored
+        return self._is_ignored(irc, msg)
 
     def invalidCommand(self, irc, msg, tokens):
-        if not self._is_not_ignored(irc, msg):
+        if self._is_ignored(irc, msg):
             irc.noReply()
 
 

--- a/IgnoreNonVoice/plugin.py
+++ b/IgnoreNonVoice/plugin.py
@@ -42,8 +42,13 @@ except ImportError:
     _ = lambda x:x
 
 class IgnoreNonVoice(callbacks.Plugin):
-    """Add the help for "@plugin help IgnoreNonVoice" here
-    This should describe *how* to use this plugin."""
+    """
+    This plugin ignores users who aren't voiced. Can also be configured
+    to only work when the channel is moderated `mode +m`. Useful with
+    reduced moderation (`mode +z`) on charybdis-based IRCds (including
+    freenode's ircd-seven).
+    """
+
     def __init__(self, irc):
         super(IgnoreNonVoice, self).__init__(irc)
         callbacks.Commands.pre_command_callbacks.append(


### PR DESCRIPTION
The plugin should ignore invalid commands when the user is being ignored, rather than when they're *not* being ignored.

The `_is_not_ignored` function was incorrectly named, as it actually checks whether the user *is* ignored.