### PR TITLE
Fix issue with getting page text for display

### DIFF
--- a/Wikipedia/plugin.py
+++ b/Wikipedia/plugin.py
@@ -159,7 +159,7 @@ class Wikipedia(callbacks.Plugin):
             reply += format(_('This article appears to be a talk page: %u'), addr)
         else:
             ##### etree!
-            p = tree.xpath("//div[@id='mw-content-text']/p[1]")
+            p = tree.xpath("//div[@id='mw-content-text']//p[1]")
             if len(p) == 0 or addr.endswith('Special:Search'):
                 if 'wikipedia:wikiproject' in addr.lower():
                     reply += format(_('This page appears to be a WikiProject page, '


### PR DESCRIPTION
Something changed in Wikipedia or its plugin where by the existing code for reading data from the page itself is broken.  That said, the fix is to use two slashes before the `p[1]` for the `xpath` call.  This allows data to be properly read from the Wikipedia page.

This was tested in `#limnoria-bots` on IRC as well, with my bot, Archangel (which was spun up for this test only).