### PR TITLE
WebStats: fix links page on python 3.7.2

### DIFF
--- a/WebStats/plugin.py
+++ b/WebStats/plugin.py
@@ -379,7 +379,10 @@ class WebStatsServerCallback(httpserver.SupyHTTPServerCallback):
             self.send_header('Content-type', content_type)
             self.end_headers()
             if sys.version_info[0] >= 3:
-                output = output.encode()
+                try:
+                    output = output.encode()
+                except:
+                    pass
             self.wfile.write(output)
 
     def get_index(self):


### PR DESCRIPTION
Work-around for getting a:

'bytes' object has no attribute 'encode'

error on the links page in WebStats.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>