### PR TITLE
SupyML: Added correct handling of <success> messages and errors 

### DIFF
--- a/SupyML/README.md
+++ b/SupyML/README.md
@@ -92,6 +92,11 @@ The syntax of the while loop is:
 
 The statement is repeated while the boolean expression evaluates to true.
 
+Note:
+A "success" message (default text: "The operation succeeded.") always evaluates to true, regardless of the optional text)
+An expression that raises an error always evaluates to false, even if the returned string would be true, even if it's a success message.
+This can be avoided by a nested exception handler that catches the error message, see exception handling below.
+
 OnceIf loop
 ----------
 
@@ -101,7 +106,8 @@ The syntax of the onceif statement is:
 <loop><onceif>boolean expression</onceif>statement</loop>
 ```
 
-The statement is expressed exactly once iff the boolean expression evaluates to true.
+The statement is expressed exactly once iff the boolean expression evaluates to true. (See above)
+
 
 Range loop
 ----------
@@ -129,7 +135,7 @@ The syntax of the foreach loop is:
 ```
 
 The statement is repeated once for each token in the token expression, or never if the expression is empty.
-The current tokene during any iteration is accessible through the loop variable. Example:
+The current token during any iteration is accessible through the loop variable. Example:
 
 ```
 <loop><foreach>foo bar baz</foreach>I have <var name="loop"/>.</loop>
@@ -252,10 +258,19 @@ eval <utilities>last <echo><loop><range>3</range>"\"\\\"<echo>This is iteration 
 
 which outputs 'This is iteration 2'.
 
+To make this easier, SupyML utilizes the &lt;quot&gt; command. It accepts a parameter **l**, which describes the desired nesting level.
+The above expressions can such be written as:
+
+```
+eval <utilities>last <loop><range>3</range><quot l="2">This is iteration <var name="loop"/></quot></loop></utilities>
+eval <utilities>last <echo><loop><range>3</range><quot l="3">This is iteration <var name="loop"/></quot></loop></echo></utilities>
+```
+
+
 This needs to be taken in mind also in combination with the Alias or Aka or other modules, for example in:
 
 ```
-aka add repeat "eval <utilities>last <loop><range>$1</range>\"\\\"<echo>This is iteration <var name=\"loop\"/></echo>\\\"\"</loop></utilities>"
+aka add repeat "eval <utilities>last <loop><range>$1</range><quot l=\"2\"><echo>This is iteration <var name=\"loop\"/></echo></quot></loop></utilities>"
 repeat 3
 ``` 
 

--- a/SupyML/plugin.py
+++ b/SupyML/plugin.py
@@ -65,6 +65,9 @@ class LoopTypeIsMissing(Exception):
 class MaximumNodesNumberExceeded(Exception):
     pass
 
+class NotAValidIntNumber(Exception):
+    pass
+
 class SupyMLParser:
     def __init__(self, plugin, irc, msg, code, maxNodes):
         self._plugin = plugin
@@ -213,11 +216,13 @@ class SupyMLParser:
                 try:
                     level=int(node.attributes['l'].value)
                 except:
-                    pass
-                if level<1: level=1
-                if level>self._maxNodes:
-                    raise MaximumNodesNumberExceeded('Attempted to quote more levels than currently allowed on this bot.')
-            value=self._quotRecursive(self._unescape(arguments),level)
+                    raise NotAValidIntNumber('Quot level must be a valid whole number.')
+                if level>10: # hardcoded - due to exponential string growth, bot will crash if much beyond that
+                    raise MaximumNodesNumberExceeded('Attempted to quote more levels than possible. Max 10.')
+            if level>=1:
+                value = self._quotRecursive(self._unescape(arguments),level)
+            else:
+                value = self._unescape(arguments)
         else:
             value = self._run(node.nodeName + ' ' + arguments, nested)
 

--- a/SupyML/test.py
+++ b/SupyML/test.py
@@ -264,6 +264,23 @@ class SupyMLTestCase(ChannelPluginTestCase):
         self.assertResponse('SupyML eval <raise>MyError</raise>','Error: MyError')
         self.assertError('SupyML eval <raise>MyError</raise>')
 
+    def testSuccessAndError(self):
+        self.assertResponse('SupyML eval <loop><onceif><success /></onceif>foo</loop>','foo')
+        self.assertResponse('SupyML eval <loop><onceif><success>This stuff succeeded</success></onceif>foo</loop>','foo')
+        self.assertResponse('SupyML eval <echo><loop><onceif><echo>This stuff succeeded</echo></onceif>foo</loop>bar</echo>','bar')
+        self.assertResponse('SupyML eval <loop><onceif>1</onceif>foo</loop>','foo')
+        self.assertResponse('SupyML eval <loop><onceif>true</onceif>foo</loop>','foo')
+        self.assertResponse('SupyML eval <catch><try>'
+                                             '<loop><onceif><raise>true</raise></onceif>foo</loop>'
+                                             '</try>try:<var name="try"/> catch:<var name="catch"/></catch>'
+                                ,'try: catch:true')
+
+    def testQuotation(self):
+        self.assertResponse('SupyML eval <quot><echo>foo</echo></quot>','"foo"')
+        self.assertResponse('SupyML eval <echo>foo <quot><echo>bar baz</echo></quot></echo>','foo bar baz')
+        self.assertResponse('SupyML eval <echo>foo <quot l="2"><echo>bar baz</echo></quot></echo>','foo "bar baz"')
+        self.assertResponse('SupyML eval <utilities>last <echo>foo <quot l="2"><echo>bar baz</echo></quot></echo></utilities>','bar baz')
+
     def testWarnings(self):
         self.assertResponse('SupyML eval <echo>'
                                 '<set name="">'


### PR DESCRIPTION
in onceif/while statements, also added text quoting helper <quot> for compound responses.

I has these small improvements in the work, when I noticed that the original pull request was already merged.

While this improvement is not strictly needed, it makes use of SupyML easier (espcially regarding quoted multi-word responses) and more predictable when it comes to how error and success messages are interpreted by if/while statements

a success message is evaluated as "true" - regardless of the configured wording of that message - even if none
a raised and uncaught error within the onceif/while expression is always considered false - regardless of the returned text

a success message along with a simultaneously propagating error message is considered False
(example: eval <loop><onceif><success><raise>true</raise></success></onceif>nope</loop> -- result: "Error: true")
