### PR TITLE
Update plugin.py

### DIFF
--- a/Iwant/plugin.py
+++ b/Iwant/plugin.py
@@ -85,7 +85,10 @@ class Iwant(callbacks.Plugin):
         indexes = range(1, len(wishlist) + 1)
         wishlist_with_index = zip(indexes, wishlist)
         formatted_wishlist = [_('#%i: %s') % x for x in wishlist_with_index]
-        irc.reply(utils.str.format('%L', formatted_wishlist))
+        if formatted_wishlist:
+            irc.reply(utils.str.format('%L', formatted_wishlist))
+        else:
+            irc.reply(_("There are currently no wishes"))
     list = wrap(list, ['channel'])
 
     @internationalizeDocstring


### PR DESCRIPTION
Add reply of `There are currently no wishes` if there's no wants instead the default `Error: I tried to send you an empty message.` so it's less confusing
This change was provided on IRC by the author :grin: