### PR TITLE
Json: Migrate to `jq`

### DIFF
--- a/Json/plugin.py
+++ b/Json/plugin.py
@@ -43,10 +43,9 @@ except ImportError:
     # without the i18n module
     _ = lambda x: x
 try:
-    import pyjq
+    import jq
 except ImportError:
-    raise callbacks.Error('You have to install pyjq (not to be confused '
-                          'with "jq" or "python-jq").')
+    raise callbacks.Error('You have to install python-jq.')
 
 
 class Json(callbacks.Plugin):
@@ -59,7 +58,7 @@ class Json(callbacks.Plugin):
         value.
         See http://stedolan.github.io/jq/tutorial/ to learn about the
         selector syntax."""
-        irc.reply(pyjq.first(selector, json.loads(data)))
+        irc.reply(jq.compile(selector).input_value(json.loads(data)).first())
     get = wrap(get, ['something', 'text'])
 
 


### PR DESCRIPTION
It seems like `jq` is the only actively maintained bindings lib:
* https://pypi.org/project/jq/ (Latest version: Jan 16, 2026)
* https://pypi.org/project/jqpy/ (Latest version: Dec 7, 2023)
* https://pypi.org/project/pyjq/ (Latest version: Aug 2, 2022)